### PR TITLE
Bump to textual-image[textual]>=0.7.0 and remove workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "rich",
     "textual",
-    "textual-image[textual]>=0.6.6",
+    "textual-image[textual]>=0.7.0",
 ]
 
 [dependency-groups]

--- a/tuitorial/widgets.py
+++ b/tuitorial/widgets.py
@@ -182,9 +182,7 @@ class ContentContainer(Container):
         super().__init__()
         self.code_display = CodeDisplay(code, [], dim_background=True)
         self.markdown = Markdown(code, id="markdown")
-        # Create a container for the image widget instead of the Image itself
-        # because of issue https://github.com/lnqs/textual-image/issues/43
-        self.image_container = Container(id="image-container")
+        self.image_container = Container(Image(id="image"), id="image-container")
 
     def compose(self) -> ComposeResult:
         """Compose the container with both widgets."""
@@ -210,14 +208,9 @@ class ContentContainer(Container):
         self.code_display.styles.display = "none"
         self.markdown.styles.display = "none"
         self.image_container.styles.display = "block"
-        # TODO: Change when https://github.com/lnqs/textual-image/issues/43 is fixed
-        # Remove the old image widget (if any) and add a new one
-        await self.image_container.remove_children()
-        image_widget = Image(step.image, id="image")
-        assert self.is_mounted
-        assert self.image_container.is_mounted
-        if self.image_container.is_mounted:
-            await self.image_container.mount(image_widget)
+
+        image_widget = self.query_one("#image", Image)
+        image_widget.image = step.image
 
         # Set the image size using styles
         if step.width is not None:

--- a/uv.lock
+++ b/uv.lock
@@ -827,15 +827,15 @@ wheels = [
 
 [[package]]
 name = "textual-image"
-version = "0.6.6"
+version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pillow" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/c4/6ae0bcd2cba883a3e54e15746f8c85e0b803adede4fc59d7693107c16197/textual_image-0.6.6.tar.gz", hash = "sha256:df4a64955268f02fb12420952bae30ac0da1d7c6c1bb3d92ade611a4a16f06d9", size = 107700 }
+sdist = { url = "https://files.pythonhosted.org/packages/62/81/ca6f886d489c94ed5cf9f4c4b178828e3d30fb12276338e641691fad9eb8/textual_image-0.7.0.tar.gz", hash = "sha256:5cd4a0808c3455afeb836a62443bc292723576a96346ef7a06666f1b2b8752e0", size = 107720 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/bd/362db64ce8be6179a5a6010e54769b3441654a2b45ad9cdcfa0832b15a30/textual_image-0.6.6-py3-none-any.whl", hash = "sha256:7683a71c294ac4081d30296182d43ff73bf4d57c0657e7e8cf1aa93911909f6f", size = 108425 },
+    { url = "https://files.pythonhosted.org/packages/25/62/da4f7d1a078ceb4eecf90102b255b5e47c07c69d17a3fd28b8deac57c356/textual_image-0.7.0-py3-none-any.whl", hash = "sha256:920ca6ae67fae015136896aaa3641033ac1ccc86e9313a430f01ceec4455384f", size = 108443 },
 ]
 
 [package.optional-dependencies]
@@ -911,7 +911,7 @@ wheels = [
 
 [[package]]
 name = "tuitorial"
-version = "0.3.0.dev25+main.gc75e96d.dirty"
+version = "0.3.0.dev27+fix.image.g0e8abe3.dirty"
 source = { editable = "." }
 dependencies = [
     { name = "pyfiglet" },
@@ -937,7 +937,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich" },
     { name = "textual" },
-    { name = "textual-image", extras = ["textual"], specifier = ">=0.6.6" },
+    { name = "textual-image", extras = ["textual"], specifier = ">=0.7.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
@Inqs fixed https://github.com/lnqs/textual-image/issues/43 in https://github.com/lnqs/textual-image/pull/46.

