### PR TITLE
Add regex flag support and enable multiline by default

### DIFF
--- a/tuitorial/highlighting.py
+++ b/tuitorial/highlighting.py
@@ -25,7 +25,6 @@ class FocusType(Enum):
     SYNTAX = auto()
     MARKDOWN = auto()
 
-
 @dataclass
 class Focus:
     """A pattern to focus on with its style."""
@@ -69,10 +68,11 @@ class Focus:
         cls,
         pattern: str | Pattern,
         style: Style = Style(color="green", bold=True),  # noqa: B008
+        flags: re.RegexFlag = re.MULTILINE,
     ) -> Focus:
         """Create a focus for a regular expression."""
         if isinstance(pattern, str):
-            pattern = re.compile(pattern)
+            pattern = re.compile(pattern, flags)
         return cls(pattern, style, FocusType.REGEX)
 
     @classmethod


### PR DESCRIPTION
The Readme makes implicit use of the multiline flag with the special character '$'
```
# Your code to present
code = '''
def hello(name: str) -> str:
    return f"Hello, {name}!"

def main():
    print(hello("World"))
'''

# Define tutorial steps
steps = [
    Step(
        "Function Definition",
        [Focus.regex(r"def hello.*:$", style="bold yellow")]
    ),
```

However, the multiline flag is not enabled by default in the `re` module in Python, neither it is passed as parameter in the implementation of `Focus.regex`. This makes the Readme example not to work on the highlight of the function definition, see how it doesnt highlight in yellow the `def hello` line
![image](https://github.com/user-attachments/assets/8bc11438-2692-4122-8212-3cbf6952b313)

Just adding the possibility to pass RegexFlag to the Focus.Regex method, and enabling multiline as default, solves the problem

```python
    @classmethod
    def regex(
        cls,
        pattern: str | Pattern,
        style: Style = Style(color="green", bold=True),  # noqa: B008
        flags: re.RegexFlag = re.MULTILINE,
    ) -> Focus:
        """Create a focus for a regular expression."""
        if isinstance(pattern, str):
            pattern = re.compile(pattern, flags)
        return cls(pattern, style, FocusType.REGEX)

```

![image](https://github.com/user-attachments/assets/2c384470-8041-4b51-aa36-e65d8c023e36)
