### PR TITLE
fix: correct duplicated text in YAML bullet points example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1525,7 +1525,7 @@ chapters:
       - text: "Here is the second point."
         extra: "More details about point 2."
       - text: "And finally, the third point."
-        extra: "More details about point 2."
+        extra: "Final thoughts on point 3."
       - Fourth point without extra
     style: "green bold"
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 - **Reproducible and Versionable:** Define tutorials in code (Python or YAML) for easy tracking and updates.
 - **Lightweight and Fast:** No more bloated presentation software.
 - **Perfect for Nerds:** Ideal for explaining code, technical workshops, interactive documentation, and anyone who loves the terminal.
-- **Parametrize:** Create dynamic tutorials driven by code snippets and focus points.
+- **Parameterize:** Create dynamic tutorials driven by code snippets and focus points.
 
 ## 📸 Recording
 


### PR DESCRIPTION
## Summary

- Fixed typo in README.md where the extra text for the third bullet point incorrectly referenced "point 2" instead of "point 3"
- Updated the YAML example to match the Python example (line 1528)

## Changes

Changed:
```yaml
extra: "More details about point 2."
```

To:
```yaml
extra: "Final thoughts on point 3."
```

## Test plan

- [x] Read through the YAML example section
- [x] Verify text now matches the Python example above it
- [x] Confirm consistency across documentation